### PR TITLE
Create script to launch local server

### DIFF
--- a/TOR-MESSAGING.md
+++ b/TOR-MESSAGING.md
@@ -1,0 +1,188 @@
+# Tor Messaging System
+
+A simple peer-to-peer messaging system that works over Tor hidden services.
+
+## Quick Start
+
+### Terminal 1: Launch the Server
+
+```bash
+./launch-server.sh
+```
+
+This will:
+1. Build the server binary (if needed)
+2. Start a Tor hidden service
+3. Display the `.onion` address
+4. Save the address to `.onion_address` file
+5. Wait for connections
+
+The output will show debugging information as connections are made and messages are sent.
+
+### Terminal 2 (or different computer): Connect as a Client
+
+```bash
+./connect-client.sh
+```
+
+This will:
+1. Build the client binary (if needed)
+2. Read the `.onion` address from the file
+3. Connect to the server over Tor
+4. Allow you to type messages
+
+Once connected, type messages and press Enter to send them. All connected clients will see all messages.
+
+## How It Works
+
+### Server
+
+The server:
+- Creates a Tor hidden service on port 9999
+- Accepts multiple client connections
+- Broadcasts messages from any client to all other connected clients
+- Displays connection and message activity
+
+### Client
+
+The client:
+- Connects to the server's .onion address via Tor
+- Sends messages you type to the server
+- Displays messages from other clients
+- Works from any computer with Tor access
+
+### Address Sharing
+
+The server saves its `.onion` address to `.onion_address` in the project directory.
+
+**For same machine**: Just run `./connect-client.sh`
+
+**For different machines**:
+1. Copy the `.onion` address from the server terminal
+2. On the client machine, run:
+   ```bash
+   cargo run --release --bin tor-msg-client <onion-address>:9999
+   ```
+
+Example:
+```bash
+cargo run --release --bin tor-msg-client abc123xyz456.onion:9999
+```
+
+## Example Session
+
+**Server Terminal:**
+```
+=== Launching Tor Message Server ===
+
+Building server binary...
+
+Starting server...
+The onion address will be saved to: .onion_address
+
+----------------------------------------
+
+=== Tor Message Server ===
+
+[1/3] Bootstrapping to Tor network...
+[1/3] ✓ Connected to Tor
+
+[2/3] Launching hidden service...
+[2/3] ✓ Hidden service launched
+
+========================================
+ONION_ADDRESS=abc123xyz456.onion
+========================================
+
+✓ Onion address saved to .onion_address
+
+[3/3] Waiting for connections on port 9999...
+
+Server is ready! Clients can connect to:
+  abc123xyz456.onion:9999
+
+Press Ctrl+C to shut down
+
+[Server] Client 1 connected
+[Server] Client 1 sent: Hello from client 1
+[Server] Client 2 connected
+[Server] Client 2 sent: Hi from client 2
+```
+
+**Client Terminal:**
+```
+=== Connecting to Tor Message Server ===
+
+Connecting to: abc123xyz456.onion:9999
+
+----------------------------------------
+
+=== Tor Message Client ===
+
+[1/3] Bootstrapping to Tor network...
+[1/3] ✓ Connected to Tor
+
+[2/3] Connecting to abc123xyz456.onion:9999...
+[2/3] ✓ Connected to hidden service
+
+[3/3] Connection established!
+
+Type messages and press Enter to send.
+Press Ctrl+C to quit.
+
+Welcome! You are client #1. Type messages to broadcast.
+Hello from client 1
+[Client 1] Hello from client 1
+[Client 2] Hi from client 2
+```
+
+## Security Notes
+
+- **Current version**: Knowing the `.onion` address is the only security
+- **No encryption**: Messages are sent in plaintext (but over Tor)
+- **No authentication**: Anyone with the address can connect
+- **Future versions** will add proper encryption and authentication
+
+## Debugging
+
+### Server won't start
+
+- Check Tor connectivity: `cargo run --bin tor-check`
+- Make sure port 9999 is available (not already in use)
+- Check firewall settings
+
+### Client can't connect
+
+- Verify the `.onion` address is correct
+- Wait 30-60 seconds after server starts (Tor needs time to publish)
+- Check Tor connectivity: `cargo run --bin tor-check`
+- Make sure you're using port 9999
+
+### Connection is slow
+
+- Tor hidden services can be slow to establish initially
+- First connection may take 30-60 seconds
+- Subsequent connections are usually faster
+
+## Building Manually
+
+If you want to build the binaries separately:
+
+```bash
+# Build both
+cargo build --release --bin tor-msg-server --bin tor-msg-client
+
+# Run server manually
+./target/release/tor-msg-server
+
+# Run client manually (replace with actual address)
+./target/release/tor-msg-client <onion-address>:9999
+```
+
+## Files
+
+- `src/bin/tor-msg-server.rs` - Server implementation
+- `src/bin/tor-msg-client.rs` - Client implementation
+- `launch-server.sh` - Convenience script to launch server
+- `connect-client.sh` - Convenience script to connect client
+- `.onion_address` - Generated file containing the server's address

--- a/connect-client.sh
+++ b/connect-client.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Connect to the Tor message server using the saved onion address
+
+set -e
+
+ONION_FILE=".onion_address"
+BINARY="target/release/tor-msg-client"
+
+echo "=== Connecting to Tor Message Server ==="
+echo
+
+# Build the binary if it doesn't exist
+if [ ! -f "$BINARY" ]; then
+    echo "Building client binary..."
+    cargo build --release --bin tor-msg-client
+    echo
+fi
+
+# Check if onion address file exists
+if [ ! -f "$ONION_FILE" ]; then
+    echo "Error: Onion address file not found: $ONION_FILE"
+    echo
+    echo "Please start the server first using ./launch-server.sh"
+    echo "Or provide the onion address manually:"
+    echo "  $BINARY <onion-address>:9999"
+    exit 1
+fi
+
+# Read the onion address
+ONION_ADDR=$(cat "$ONION_FILE")
+
+echo "Connecting to: $ONION_ADDR:9999"
+echo
+echo "----------------------------------------"
+echo
+
+# Run the client
+$BINARY "$ONION_ADDR:9999"

--- a/launch-server.sh
+++ b/launch-server.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Launch the Tor message server and save the onion address to a file
+
+set -e
+
+ONION_FILE=".onion_address"
+BINARY="target/release/tor-msg-server"
+
+echo "=== Launching Tor Message Server ==="
+echo
+
+# Build the binary if it doesn't exist
+if [ ! -f "$BINARY" ]; then
+    echo "Building server binary..."
+    cargo build --release --bin tor-msg-server
+    echo
+fi
+
+# Remove old onion address file if it exists
+rm -f "$ONION_FILE"
+
+echo "Starting server..."
+echo "The onion address will be saved to: $ONION_FILE"
+echo
+echo "----------------------------------------"
+echo
+
+# Run the server and capture the first line of stdout (the onion address)
+# while still showing all stderr output
+$BINARY 2>&1 | while IFS= read -r line; do
+    # The first line from stdout is the onion address
+    if [ ! -f "$ONION_FILE" ]; then
+        # Check if this looks like an onion address
+        if [[ "$line" =~ \.onion$ ]]; then
+            echo "$line" > "$ONION_FILE"
+            echo "✓ Onion address saved to $ONION_FILE"
+            echo
+        fi
+    fi
+    # Print all output to terminal
+    echo "$line"
+done

--- a/src/bin/tor-msg-client.rs
+++ b/src/bin/tor-msg-client.rs
@@ -1,0 +1,126 @@
+//! Simple Tor message client
+//!
+//! Connects to a Tor hidden service and sends/receives messages.
+//! Usage: tor-msg-client <onion-address>:9999
+
+use anyhow::{Context, Result};
+use std::env;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use arti_client::TorClient;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Get onion address from command line
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Usage: {} <onion-address>:9999", args[0]);
+        eprintln!();
+        eprintln!("Example:");
+        eprintln!("  {} abcdef1234567890.onion:9999", args[0]);
+        std::process::exit(1);
+    }
+
+    let target = &args[1];
+
+    // Parse the target address (format: hostname:port)
+    let parts: Vec<&str> = target.split(':').collect();
+    if parts.len() != 2 {
+        eprintln!("Error: Address must be in format <hostname>:<port>");
+        eprintln!("Example: abcdef1234567890.onion:9999");
+        std::process::exit(1);
+    }
+
+    let hostname = parts[0];
+    let port: u16 = parts[1].parse().context("Invalid port number")?;
+
+    eprintln!("=== Tor Message Client ===");
+    eprintln!();
+    eprintln!("[1/3] Bootstrapping to Tor network...");
+
+    // Initialize Tor client
+    let tor_client = TorClient::create_bootstrapped(Default::default())
+        .await
+        .context("Failed to bootstrap Tor client")?;
+
+    eprintln!("[1/3] ✓ Connected to Tor");
+    eprintln!();
+
+    // Connect to the hidden service
+    eprintln!("[2/3] Connecting to {}:{}...", hostname, port);
+    let mut stream = tor_client
+        .connect((hostname, port))
+        .await
+        .context("Failed to connect to hidden service")?;
+
+    eprintln!("[2/3] ✓ Connected to hidden service");
+    eprintln!();
+    eprintln!("[3/3] Connection established!");
+    eprintln!();
+    eprintln!("Type messages and press Enter to send.");
+    eprintln!("Press Ctrl+C to quit.");
+    eprintln!();
+
+    // Split stream into read and write halves
+    let (mut read_half, mut write_half) = tokio::io::split(stream);
+
+    // Spawn a task to read from the server
+    let read_task = tokio::spawn(async move {
+        let mut buffer = vec![0u8; 4096];
+        loop {
+            match read_half.read(&mut buffer).await {
+                Ok(0) => {
+                    eprintln!();
+                    eprintln!("Connection closed by server");
+                    break;
+                }
+                Ok(n) => {
+                    let msg = String::from_utf8_lossy(&buffer[..n]);
+                    print!("{}", msg);
+                    // Flush stdout to ensure message is displayed immediately
+                    use std::io::Write;
+                    std::io::stdout().flush().ok();
+                }
+                Err(e) => {
+                    eprintln!();
+                    eprintln!("Error reading from server: {}", e);
+                    break;
+                }
+            }
+        }
+    });
+
+    // Read from stdin and send to server
+    let stdin = tokio::io::stdin();
+    let mut stdin_reader = tokio::io::BufReader::new(stdin);
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+
+        // Read line from stdin
+        match tokio::io::AsyncBufReadExt::read_line(&mut stdin_reader, &mut line).await {
+            Ok(0) => {
+                // EOF
+                eprintln!();
+                eprintln!("Disconnecting...");
+                break;
+            }
+            Ok(_) => {
+                // Send to server
+                if let Err(e) = write_half.write_all(line.as_bytes()).await {
+                    eprintln!("Error sending message: {}", e);
+                    break;
+                }
+            }
+            Err(e) => {
+                eprintln!("Error reading from stdin: {}", e);
+                break;
+            }
+        }
+    }
+
+    // Cancel read task
+    read_task.abort();
+
+    Ok(())
+}

--- a/src/bin/tor-msg-server.rs
+++ b/src/bin/tor-msg-server.rs
@@ -1,0 +1,226 @@
+//! Simple Tor message server
+//!
+//! Launches a Tor hidden service that accepts connections and relays messages
+//! between connected clients. The onion address is printed to stdout.
+
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{Mutex, mpsc};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use futures::StreamExt;
+
+use arti_client::TorClient;
+use tor_hsservice::config::OnionServiceConfigBuilder;
+use tor_hsservice::{StreamRequest, handle_rend_requests};
+use tor_proto::client::stream::IncomingStreamRequest;
+use tor_cell::relaycell::msg::Connected;
+use safelog::DisplayRedacted;
+
+type ClientId = usize;
+type ClientMap = Arc<Mutex<HashMap<ClientId, mpsc::UnboundedSender<Vec<u8>>>>>;
+
+/// Handle an incoming client connection
+async fn handle_client(
+    mut stream: impl AsyncReadExt + AsyncWriteExt + Unpin + Send + 'static,
+    client_id: ClientId,
+    clients: ClientMap,
+) -> Result<()> {
+    eprintln!("[Server] Client {} connected", client_id);
+
+    // Create channel for this client
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    // Add client to the map
+    {
+        let mut clients_guard = clients.lock().await;
+        clients_guard.insert(client_id, tx);
+    }
+
+    // Send welcome message
+    let welcome = format!("Welcome! You are client #{}. Type messages to broadcast.\n", client_id);
+    if let Err(e) = stream.write_all(welcome.as_bytes()).await {
+        eprintln!("[Server] Failed to send welcome to client {}: {}", client_id, e);
+    }
+
+    // Split the stream for reading and writing
+    let (mut read_half, mut write_half) = tokio::io::split(stream);
+
+    // Spawn task to handle outgoing messages to this client
+    let client_id_clone = client_id;
+    let write_task = tokio::spawn(async move {
+        while let Some(msg) = rx.recv().await {
+            if let Err(e) = write_half.write_all(&msg).await {
+                eprintln!("[Server] Failed to send to client {}: {}", client_id_clone, e);
+                break;
+            }
+        }
+    });
+
+    // Handle incoming messages from this client
+    let mut buffer = vec![0u8; 4096];
+    loop {
+        match read_half.read(&mut buffer).await {
+            Ok(0) => {
+                // Connection closed
+                eprintln!("[Server] Client {} disconnected", client_id);
+                break;
+            }
+            Ok(n) => {
+                let msg = &buffer[..n];
+                let msg_str = String::from_utf8_lossy(msg);
+                eprintln!("[Server] Client {} sent: {}", client_id, msg_str.trim());
+
+                // Broadcast to all clients (including sender for echo)
+                let broadcast_msg = format!("[Client {}] {}", client_id, msg_str);
+                let broadcast_bytes = broadcast_msg.as_bytes().to_vec();
+
+                let clients_guard = clients.lock().await;
+                for (id, tx) in clients_guard.iter() {
+                    if let Err(e) = tx.send(broadcast_bytes.clone()) {
+                        eprintln!("[Server] Failed to queue message for client {}: {}", id, e);
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("[Server] Error reading from client {}: {}", client_id, e);
+                break;
+            }
+        }
+    }
+
+    // Remove client from map
+    {
+        let mut clients_guard = clients.lock().await;
+        clients_guard.remove(&client_id);
+    }
+
+    // Cancel write task
+    write_task.abort();
+
+    Ok(())
+}
+
+/// Handle an incoming stream request from the onion service
+async fn handle_stream_request(
+    stream_request: StreamRequest,
+    clients: ClientMap,
+    next_client_id: Arc<Mutex<ClientId>>,
+) -> Result<()> {
+    match stream_request.request() {
+        IncomingStreamRequest::Begin(begin) => {
+            let port = begin.port();
+
+            // Only accept connections on port 9999
+            if port != 9999 {
+                eprintln!("[Server] Rejecting connection on unexpected port {}", port);
+                stream_request.shutdown_circuit()?;
+                return Ok(());
+            }
+
+            // Accept the stream
+            let stream = stream_request
+                .accept(Connected::new_empty())
+                .await
+                .context("Failed to accept stream from onion service")?;
+
+            // Assign client ID
+            let client_id = {
+                let mut id_guard = next_client_id.lock().await;
+                let id = *id_guard;
+                *id_guard += 1;
+                id
+            };
+
+            // Handle the client in a separate task
+            tokio::spawn(async move {
+                if let Err(e) = handle_client(stream, client_id, clients).await {
+                    eprintln!("[Server] Error handling client {}: {}", client_id, e);
+                }
+            });
+        }
+        IncomingStreamRequest::BeginDir(_) => {
+            stream_request.shutdown_circuit()?;
+        }
+        _ => {
+            stream_request.shutdown_circuit()?;
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    eprintln!("=== Tor Message Server ===");
+    eprintln!();
+
+    // Initialize Tor client
+    eprintln!("[1/3] Bootstrapping to Tor network...");
+    let tor_client = TorClient::create_bootstrapped(Default::default())
+        .await
+        .context("Failed to bootstrap Tor client")?;
+    eprintln!("[1/3] ✓ Connected to Tor");
+    eprintln!();
+
+    // Launch onion service
+    eprintln!("[2/3] Launching hidden service...");
+    let svc_config = OnionServiceConfigBuilder::default()
+        .nickname("tor-msg-server".parse()?)
+        .build()?;
+
+    let (onion_service, request_stream) = tor_client
+        .launch_onion_service(svc_config)
+        .context("Failed to launch onion service")?;
+
+    // Wait for onion address
+    let onion_address = loop {
+        if let Some(addr) = onion_service.onion_address() {
+            break addr;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    };
+
+    eprintln!("[2/3] ✓ Hidden service launched");
+    eprintln!();
+
+    // Print the onion address (this can be captured by scripts)
+    eprintln!("========================================");
+    eprintln!("ONION_ADDRESS={}", onion_address.display_unredacted());
+    eprintln!("========================================");
+    eprintln!();
+
+    // Also print it to stdout for easy capture
+    println!("{}", onion_address.display_unredacted());
+
+    eprintln!("[3/3] Waiting for connections on port 9999...");
+    eprintln!();
+    eprintln!("Server is ready! Clients can connect to:");
+    eprintln!("  {}:9999", onion_address.display_unredacted());
+    eprintln!();
+    eprintln!("Press Ctrl+C to shut down");
+    eprintln!();
+
+    // Set up client tracking
+    let clients: ClientMap = Arc::new(Mutex::new(HashMap::new()));
+    let next_client_id = Arc::new(Mutex::new(1));
+
+    // Handle incoming requests
+    let stream_requests = handle_rend_requests(request_stream);
+    tokio::pin!(stream_requests);
+
+    while let Some(stream_request) = stream_requests.next().await {
+        let clients_clone = Arc::clone(&clients);
+        let next_id_clone = Arc::clone(&next_client_id);
+
+        tokio::spawn(async move {
+            if let Err(e) = handle_stream_request(stream_request, clients_clone, next_id_clone).await {
+                eprintln!("[Server] Error handling stream: {}", e);
+            }
+        });
+    }
+
+    eprintln!();
+    eprintln!("Server shutting down...");
+    Ok(())
+}


### PR DESCRIPTION
This commit adds a simple peer-to-peer messaging system over Tor:

New binaries:
- tor-msg-server: Launches a Tor hidden service that relays messages between connected clients
- tor-msg-client: Connects to a hidden service and sends/receives messages

Convenience scripts:
- launch-server.sh: Builds and runs the server, saves .onion address to .onion_address file for easy client connection
- connect-client.sh: Reads .onion address from file and connects automatically

Features:
- Multi-client chat: All connected clients receive messages from all other clients
- Easy setup: One script to launch server, one to connect
- Cross-machine support: Copy .onion address to connect from different computers
- Moderate debugging output: Shows connections and messages without excessive noise

Documentation:
- TOR-MESSAGING.md: Complete guide with examples and troubleshooting

This provides a simple foundation for secure messaging over Tor that can be extended with encryption and authentication in the future.