### PR TITLE
Fix tor-http-client compilation - add async I/O trait imports

### DIFF
--- a/src/bin/tor-http-client.rs
+++ b/src/bin/tor-http-client.rs
@@ -13,7 +13,7 @@
 use anyhow::{Context, Result, bail};
 use arti_client::{TorClient, TorClientConfig};
 use tor_rtcompat::PreferredRuntime;
-use std::io::{Read, Write};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{info, error};
 use tracing_subscriber;
 


### PR DESCRIPTION
Fixed compilation errors by importing AsyncReadExt and AsyncWriteExt from tokio::io instead of using std::io Read/Write traits.

The tor-http-client now builds successfully and works correctly with the tor-connect.sh script for pure Arti Tor connections.

Tested:
- Binary compiles without errors
- tor-connect.sh script finds and runs the binary correctly
- Argument parsing works as expected