### PR TITLE
Add comprehensive lock file cleanup and process management

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,36 @@ eddi/
 
 ## Troubleshooting
 
+### "State already locked" Error
+
+If you see `State already locked` or `Another process is managing the directory`:
+
+**Quick Fix:**
+```bash
+# Option 1: Use force mode (kills old processes automatically)
+./eddi-server --force
+
+# Option 2: Use the cleanup tool (interactive)
+./eddi-cleanup
+```
+
+**What's happening:**
+- Another eddi instance is still running, or
+- A previous instance crashed and left lock files behind
+
+**Manual cleanup:**
+```bash
+# 1. Find and kill running processes
+pgrep -f eddi
+kill <PID>
+
+# 2. Remove Arti lock files
+find ~/.local/share/arti -name "state.lock" -delete
+
+# 3. Clean up sockets
+rm -f /tmp/eddi*.sock
+```
+
 ### DNS Resolution Issues
 
 If you see "failed to resolve" errors:

--- a/eddi-cleanup
+++ b/eddi-cleanup
@@ -1,0 +1,144 @@
+#!/bin/bash
+# EDDI Cleanup Script
+# Kills running eddi processes and cleans up lock files
+
+set -e
+
+echo "🧹 EDDI Cleanup Tool"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Track if we found anything
+FOUND_PROCESSES=0
+FOUND_LOCKS=0
+FOUND_SOCKETS=0
+
+# 1. Find and kill running eddi processes
+echo "🔍 Step 1: Checking for running eddi processes..."
+echo ""
+
+# Find eddi processes (excluding grep and this script)
+EDDI_PIDS=$(pgrep -f "target/(debug|release)/eddi" 2>/dev/null || true)
+
+if [ -n "$EDDI_PIDS" ]; then
+    echo -e "${YELLOW}Found running eddi processes:${NC}"
+    for PID in $EDDI_PIDS; do
+        echo "  PID $PID: $(ps -p $PID -o command= 2>/dev/null || echo 'unknown')"
+    done
+    echo ""
+
+    read -p "Kill these processes? (y/N) " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        for PID in $EDDI_PIDS; do
+            echo -e "${BLUE}Killing PID $PID...${NC}"
+            kill -TERM $PID 2>/dev/null || kill -KILL $PID 2>/dev/null || true
+        done
+        sleep 1
+        echo -e "${GREEN}✓ Processes killed${NC}"
+        FOUND_PROCESSES=1
+    else
+        echo "Skipped killing processes"
+    fi
+else
+    echo -e "${GREEN}✓ No running eddi processes found${NC}"
+fi
+echo ""
+
+# 2. Clean up Arti state directory locks
+echo "🔍 Step 2: Checking for Arti lock files..."
+echo ""
+
+ARTI_DIR="$HOME/.local/share/arti"
+
+if [ -d "$ARTI_DIR" ]; then
+    # Find lock files
+    LOCK_FILES=$(find "$ARTI_DIR" -type f -name "*.lock" 2>/dev/null || true)
+    LOCK_DIRS=$(find "$ARTI_DIR" -type d -name "*lock*" 2>/dev/null || true)
+
+    if [ -n "$LOCK_FILES" ] || [ -n "$LOCK_DIRS" ]; then
+        echo -e "${YELLOW}Found lock files/directories:${NC}"
+        [ -n "$LOCK_FILES" ] && echo "$LOCK_FILES"
+        [ -n "$LOCK_DIRS" ] && echo "$LOCK_DIRS"
+        echo ""
+
+        read -p "Remove these locks? (y/N) " -n 1 -r
+        echo ""
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            [ -n "$LOCK_FILES" ] && echo "$LOCK_FILES" | xargs rm -f
+            [ -n "$LOCK_DIRS" ] && echo "$LOCK_DIRS" | xargs rm -rf
+            echo -e "${GREEN}✓ Locks removed${NC}"
+            FOUND_LOCKS=1
+        else
+            echo "Skipped removing locks"
+        fi
+    else
+        echo -e "${GREEN}✓ No lock files found${NC}"
+    fi
+
+    # Also check for state.lock files specifically
+    STATE_LOCKS=$(find "$ARTI_DIR" -name "state.lock" 2>/dev/null || true)
+    if [ -n "$STATE_LOCKS" ]; then
+        echo ""
+        echo -e "${YELLOW}Found state.lock files:${NC}"
+        echo "$STATE_LOCKS"
+        echo ""
+
+        read -p "Remove state locks? (y/N) " -n 1 -r
+        echo ""
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            echo "$STATE_LOCKS" | xargs rm -f
+            echo -e "${GREEN}✓ State locks removed${NC}"
+            FOUND_LOCKS=1
+        fi
+    fi
+else
+    echo -e "${BLUE}Note: Arti directory doesn't exist yet ($ARTI_DIR)${NC}"
+fi
+echo ""
+
+# 3. Clean up socket files
+echo "🔍 Step 3: Checking for stale socket files..."
+echo ""
+
+SOCKET_FILES=$(find /tmp -name "eddi*.sock" 2>/dev/null || true)
+
+if [ -n "$SOCKET_FILES" ]; then
+    echo -e "${YELLOW}Found socket files:${NC}"
+    echo "$SOCKET_FILES"
+    echo ""
+
+    read -p "Remove these sockets? (y/N) " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        echo "$SOCKET_FILES" | xargs rm -f
+        echo -e "${GREEN}✓ Sockets removed${NC}"
+        FOUND_SOCKETS=1
+    else
+        echo "Skipped removing sockets"
+    fi
+else
+    echo -e "${GREEN}✓ No stale socket files found${NC}"
+fi
+echo ""
+
+# 4. Summary
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [ $FOUND_PROCESSES -eq 0 ] && [ $FOUND_LOCKS -eq 0 ] && [ $FOUND_SOCKETS -eq 0 ]; then
+    echo -e "${GREEN}✨ System is clean! No cleanup needed.${NC}"
+else
+    echo -e "${GREEN}✨ Cleanup complete!${NC}"
+fi
+
+echo ""
+echo "You can now run:"
+echo "  ./eddi-server"
+echo ""

--- a/eddi-server
+++ b/eddi-server
@@ -1,11 +1,67 @@
 #!/bin/bash
 # Simple EDDI Server Launcher
-# Usage: ./eddi-server
+# Usage: ./eddi-server [--force]
+#
+# Options:
+#   --force    Automatically kill existing processes and clean locks
 
-set -e
+FORCE=0
+if [ "$1" = "--force" ] || [ "$1" = "-f" ]; then
+    FORCE=1
+fi
 
 echo "🚀 Starting EDDI Server..."
 echo ""
+
+# Check for running eddi processes
+EDDI_PIDS=$(pgrep -f "target/(debug|release)/eddi" 2>/dev/null || true)
+
+if [ -n "$EDDI_PIDS" ]; then
+    echo "⚠️  Found running eddi process(es): $EDDI_PIDS"
+
+    if [ $FORCE -eq 1 ]; then
+        echo "🔪 Force mode: Killing existing processes..."
+        for PID in $EDDI_PIDS; do
+            kill -TERM $PID 2>/dev/null || kill -KILL $PID 2>/dev/null || true
+        done
+        sleep 1
+        echo "✅ Processes killed"
+    else
+        echo ""
+        echo "Another eddi instance is running!"
+        echo "Options:"
+        echo "  1. Run './eddi-cleanup' to clean up manually"
+        echo "  2. Run './eddi-server --force' to auto-cleanup"
+        echo "  3. Kill manually: kill $EDDI_PIDS"
+        echo ""
+        exit 1
+    fi
+    echo ""
+fi
+
+# Clean up Arti locks if they exist
+ARTI_DIR="$HOME/.local/share/arti"
+if [ -d "$ARTI_DIR" ]; then
+    LOCKS_FOUND=0
+
+    # Remove state locks (these are the main culprits)
+    if find "$ARTI_DIR" -name "state.lock" 2>/dev/null | grep -q .; then
+        if [ $FORCE -eq 1 ]; then
+            echo "🧹 Removing stale Arti lock files..."
+            find "$ARTI_DIR" -name "state.lock" -delete 2>/dev/null || true
+            LOCKS_FOUND=1
+        else
+            echo "⚠️  Found Arti lock files"
+            echo "Run with --force to auto-cleanup, or use ./eddi-cleanup"
+            echo ""
+        fi
+    fi
+
+    if [ $LOCKS_FOUND -eq 1 ]; then
+        echo "✅ Lock files cleaned"
+        echo ""
+    fi
+fi
 
 # Build if needed
 if [ ! -f "target/release/eddi" ]; then

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Development runner for eddi
+# Builds and runs eddi with logging
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Create logs directory
+mkdir -p logs
+
+# Generate log filename
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+LOG_FILE="logs/eddi-run-${TIMESTAMP}.log"
+LATEST_LOG="logs/eddi-run-latest.log"
+
+echo -e "${BLUE}Building eddi application...${NC}"
+cargo build
+
+echo -e "${BLUE}Running eddi application...${NC}"
+echo "Output will be logged to $LOG_FILE"
+
+# Create symlink to latest log
+ln -sf "$(basename "$LOG_FILE")" "$LATEST_LOG"
+
+# Check for running instances
+EDDI_PIDS=$(pgrep -f "target/debug/eddi" 2>/dev/null || true)
+
+if [ -n "$EDDI_PIDS" ]; then
+    echo -e "${YELLOW}⚠️  Warning: Found running eddi process(es): $EDDI_PIDS${NC}"
+    echo ""
+    read -p "Kill existing processes? (y/N) " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        for PID in $EDDI_PIDS; do
+            kill -TERM $PID 2>/dev/null || kill -KILL $PID 2>/dev/null || true
+        done
+        sleep 1
+        echo -e "${GREEN}✓ Processes killed${NC}"
+    fi
+fi
+
+# Clean up Arti locks
+ARTI_DIR="$HOME/.local/share/arti"
+if [ -d "$ARTI_DIR" ]; then
+    if find "$ARTI_DIR" -name "state.lock" 2>/dev/null | grep -q .; then
+        echo -e "${YELLOW}⚠️  Found Arti lock files${NC}"
+        read -p "Remove lock files? (Y/n) " -n 1 -r
+        echo ""
+        if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+            find "$ARTI_DIR" -name "state.lock" -delete 2>/dev/null || true
+            echo -e "${GREEN}✓ Lock files removed${NC}"
+        fi
+    fi
+fi
+
+# Run in background and capture PID
+cargo run 2>&1 | tee "$LOG_FILE" &
+EDDI_PID=$!
+
+echo "eddi application started with PID: $EDDI_PID"
+echo "Press Ctrl+C to stop the eddi application."
+
+# Setup trap to kill eddi on script exit
+trap "echo ''; echo 'Stopping eddi...'; kill $EDDI_PID 2>/dev/null || true; exit 0" INT TERM
+
+# Wait for the process
+wait $EDDI_PID


### PR DESCRIPTION
Fixes "State already locked" error that occurs when multiple eddi instances run or when a previous instance crashed.

New tools:
- eddi-cleanup: Interactive cleanup script
  - Detects and kills running eddi processes
  - Removes Arti state.lock files
  - Cleans up stale socket files
  - Safe with confirmation prompts

- eddi-server --force: Auto-cleanup mode
  - Automatically kills existing processes
  - Removes lock files without prompting
  - Perfect for development/testing

- run.sh: Development runner
  - Builds and runs with logging
  - Interactive cleanup prompts
  - Proper signal handling
  - Log file management

Updates:
- eddi-server: Now detects conflicts and suggests solutions
- README.md: Added "State already locked" troubleshooting section with quick fixes and manual cleanup instructions

The lock issue happens when:
1. Another eddi instance is running
2. Previous instance crashed without cleanup
3. Arti state directory locks weren't released

Solutions (in order of preference):
1. ./eddi-server --force
2. ./eddi-cleanup
3. Manual: kill processes + remove locks