### PR TITLE
Fix run.sh to specify eddi binary

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -20,7 +20,7 @@ LOG_FILE="logs/eddi-run-${TIMESTAMP}.log"
 LATEST_LOG="logs/eddi-run-latest.log"
 
 echo -e "${BLUE}Building eddi application...${NC}"
-cargo build
+cargo build --bin eddi
 
 echo -e "${BLUE}Running eddi application...${NC}"
 echo "Output will be logged to $LOG_FILE"
@@ -60,7 +60,7 @@ if [ -d "$ARTI_DIR" ]; then
 fi
 
 # Run in background and capture PID
-cargo run 2>&1 | tee "$LOG_FILE" &
+cargo run --bin eddi 2>&1 | tee "$LOG_FILE" &
 EDDI_PID=$!
 
 echo "eddi application started with PID: $EDDI_PID"


### PR DESCRIPTION
Fixes error: 'cargo run could not determine which binary to run'

Changes:
- cargo build -> cargo build --bin eddi
- cargo run -> cargo run --bin eddi

The project has multiple binaries (eddi, task2, task3, tor-check, tor-http-client, tor-msg-client, tor-msg-server), so we must explicitly specify --bin eddi to run the main application.